### PR TITLE
Add spack package version for CMake (3.30.9)

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -3,7 +3,7 @@ spack:
   - mfem@4.8 +mpi +metis +lapack +zlib ^openmpi ^hypre+mpi ^metis+int64 ^suite-sparse
   - cgal@6.0
   - eigen@3.4
-  - cmake
+  - cmake@3.30.9
   - openmpi
   - suite-sparse
 


### PR DESCRIPTION
This change is to fix CMake invalid version build issue: "CMake 3.30 or higher is required.  You are running version 3.27.7" when building with Spack using Github Actions.