### PR TITLE
Fix ghost_exchange_done_ not set on single-rank MPI runs

### DIFF
--- a/src/support_domain/par_support_domain.cpp
+++ b/src/support_domain/par_support_domain.cpp
@@ -308,6 +308,7 @@ void ParSupportDomain::ExchangeGhostCoordinates()
             std::cout << "  Ghost exchange: single rank, no exchange needed ("
                       << timer.RealTime() << " s)" << std::endl;
         }
+        ghost_exchange_done_ = true;
         return;
     }
 


### PR DESCRIPTION
## Summary

Set `ghost_exchange_done_ = true` before the early return in `ExchangeGhostCoordinates()` when `nprocs == 1`.

## Details

When running with a single MPI rank, `ExchangeGhostCoordinates()` returns early (no exchange needed). Although `Update()` already sets the flag after `ExchangeGhostCoordinates()` returns, setting it at the early-return site makes the invariant local to where the return happens and guards against future refactoring.

Fixes #20.

## Test plan

- [ ] Build with `cmake -DMFEM_DIR=/opt/mfem/mfem-4.8 -DCMAKE_BUILD_TYPE=Debug ..` — `SupportDomain` target compiles cleanly
- [ ] Run solver with a single MPI rank and verify `NeighborIndices()` no longer aborts with `Must call Update() before querying neighbors`