### PR TITLE
Fix CI cache key cross-contamination between ubuntu-22.04 and ubuntu-latest

### DIFF
--- a/.github/workflows/build-from-source-with-ecl.yml
+++ b/.github/workflows/build-from-source-with-ecl.yml
@@ -74,7 +74,7 @@ jobs:
       with:
         path: |
           ${{ env.HYPRE_TOP_DIR }}/install
-        key: ${{ env.HYPRE_TOP_DIR }}-${{ runner.os }}
+        key: ${{ env.HYPRE_TOP_DIR }}-${{ matrix.os }}
 
     - name: Build HYPRE
       if: steps.cache-hypre.outputs.cache-hit != 'true'
@@ -88,7 +88,7 @@ jobs:
         path: |
           ${{ env.METIS_TOP_DIR }}/libmetis.a
           ${{ env.METIS_TOP_DIR }}/Lib
-        key: ${{ env.METIS_TOP_DIR }}-${{ runner.os }}
+        key: ${{ env.METIS_TOP_DIR }}-${{ matrix.os }}
 
     - name: Build METIS
       if: steps.cache-metis.outputs.cache-hit != 'true'
@@ -100,7 +100,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /opt/mfem/${{ env.MFEM_TOP_DIR }}
-        key: ${{ env.MFEM_TOP_DIR }}-hypre-metis-${{ runner.os }}
+        key: ${{ env.MFEM_TOP_DIR }}-hypre-metis-${{ matrix.os }}
 
     - name: Build and install MFEM 4.8
       if: steps.cache-mfem.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

- `runner.os` returns `"Linux"` for both matrix entries (`ubuntu-22.04` and `ubuntu-latest`), so HYPRE, METIS, and MFEM caches shared a single key across both runners.
- MFEM built on `ubuntu-latest` (newer glibc, C23 scanf entry points) was being reused on `ubuntu-22.04`, causing an undefined reference to `__isoc23_sscanf` at link time.
- Replace `${{ runner.os }}` with `${{ matrix.os }}` in all three cache keys so each OS variant maintains its own isolated cache.

## What changed

`.github/workflows/build-from-source-with-ecl.yml` — three cache key lines updated (HYPRE, METIS, MFEM).

## Reviewer notes

Stale cross-OS caches will be invalidated on the first run after this merges, triggering a full rebuild of HYPRE/METIS/MFEM for each matrix entry. Subsequent runs will hit the new per-OS caches as normal.